### PR TITLE
Fix deadlock when called by ASP.NET controller

### DIFF
--- a/TranslationServices.Core/TranslationServiceFacade.cs
+++ b/TranslationServices.Core/TranslationServiceFacade.cs
@@ -433,7 +433,7 @@ namespace TranslationAssistant.TranslationServices.Core
 
             toCode = LanguageNameToLanguageCode(to);
 
-            string[] result = TranslateV3Async(texts, fromCode, toCode, _CategoryID, contentType).Result;
+            string[] result = Task.Run(() => TranslateV3Async(texts, fromCode, toCode, _CategoryID, contentType)).Result;
             return result;
         }
 


### PR DESCRIPTION
Best way to fix it is to propagate async tasks to the caller, but Task.Run is a quick fix here.