### PR TITLE
On translate, return the raw text from src and translated files

### DIFF
--- a/TranslationAssistant.Business/DocumentReaderManager.cs
+++ b/TranslationAssistant.Business/DocumentReaderManager.cs
@@ -422,7 +422,6 @@ namespace TranslationAssistant.Business
         /// <param name="fullNameForDocumentToProcess">Source document file name</param>
         private static DocumentReaderResult ProcessTextDocument(string fullNameForDocumentToProcess)
         {
-            CharCounts counts = new CharCounts();
             DocumentText extractedText = new DocumentText();
             var document = File.ReadAllLines(fullNameForDocumentToProcess, Encoding.UTF8);
             List<string> lstTexts = new List<string>(document);
@@ -439,7 +438,6 @@ namespace TranslationAssistant.Business
         {
             using (SpreadsheetDocument document = SpreadsheetDocument.Open(outputDocumentFullName, true))
             {
-                CharCounts counts = new CharCounts();
                 DocumentText extractedText = new DocumentText();
                 //document.WorkbookPart.SharedStringTablePart.PutXDocument();
                 List<DocumentFormat.OpenXml.Spreadsheet.Text> lstTexts = new List<DocumentFormat.OpenXml.Spreadsheet.Text>();
@@ -478,7 +476,6 @@ namespace TranslationAssistant.Business
             using (PresentationDocument doc = PresentationDocument.Open(outputDocumentFullName, true))
             {
                 //doc.PresentationPart.PutXDocument();
-                CharCounts counts = new CharCounts();
                 DocumentText extractedText = new DocumentText();
                 List<DocumentFormat.OpenXml.Drawing.Text> texts = new List<DocumentFormat.OpenXml.Drawing.Text>();
                 List<DocumentFormat.OpenXml.Drawing.Text> notes = new List<DocumentFormat.OpenXml.Drawing.Text>();
@@ -536,7 +533,6 @@ namespace TranslationAssistant.Business
             bool ignoreHidden = false)
         {
             DocumentText extractedText = new DocumentText();
-            CharCounts counts = new CharCounts();
             using (WordprocessingDocument doc = WordprocessingDocument.Open(outputDocumentFullName, true))
             {
 

--- a/TranslationAssistant.DocumentTranslationInterface/ViewModel/DocumentTranslation.cs
+++ b/TranslationAssistant.DocumentTranslationInterface/ViewModel/DocumentTranslation.cs
@@ -193,15 +193,10 @@ namespace TranslationAssistant.DocumentTranslationInterface.ViewModel
                                             false,
                                             this.SelectedSourceLanguage,
                                             this.SelectedTargetLanguage,
-                                            this.IgnoreHiddenContent);
+                                            this.IgnoreHiddenContent,
+                                            true);
                                         resultList = resultList.Concat(tmpResultList);
 
-                                    }
-
-                                    foreach (DocumentTranslatorResult result in resultList)
-                                    {
-                                        sourceFileCharCount += result.Counts.SourceCharCount;
-                                        targetFileCharCount += result.Counts.TargetCharCount;
                                     }
                                 };
 
@@ -215,8 +210,7 @@ namespace TranslationAssistant.DocumentTranslationInterface.ViewModel
                                     }
                                     else
                                     {
-                                        string charCountText = string.Format("{0} characters in source; {1} characters in target\n", sourceFileCharCount, targetFileCharCount);
-                                        StatusText = charCountText + Properties.Resources.Common_Statustext1 + "\"."+TranslationServiceFacade.LanguageNameToLanguageCode(this.SelectedTargetLanguage)+".\"" + Properties.Resources.Common_Statustext2;
+                                        StatusText = Properties.Resources.Common_Statustext1 + "\"."+TranslationServiceFacade.LanguageNameToLanguageCode(this.SelectedTargetLanguage)+".\"" + Properties.Resources.Common_Statustext2;
                                     }
 
                                     this.IsStarted = false;


### PR DESCRIPTION
On translate, return the raw text.

This saves us two separate api requests: translate and then get raw text.